### PR TITLE
Fix healthcheck port detection

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -45,6 +45,11 @@ if (process.env.E2E_TESTS !== 'true') {
 	require('dotenv').config();
 }
 
+// Allow the PLATFORM provided PORT env to define the n8n port
+if (!process.env.N8N_PORT && process.env.PORT) {
+	process.env.N8N_PORT = process.env.PORT;
+}
+
 // Load config early to ensure `N8N_CONFIG_FILES` values are populated into `GlobalConfig`
 // _before_ typeorm entities in `@n8n/db` are loaded, as typeorm entity decorators rely on
 // `GlobalConfig.database.type` to decide on column types and timestamp syntax.


### PR DESCRIPTION
## Summary
- set `N8N_PORT` from `PORT` in startup script so containers obey platform port

## Testing
- `pnpm test` *(fails: @n8n/integration-test-utils)*

------
https://chatgpt.com/codex/tasks/task_e_684fe156fb5c8322b8a2a1105d38bed6

## Summary by Sourcery

Ensure the healthcheck endpoint uses the platform-assigned port by importing the health command and mapping PORT to N8N_PORT on startup

Enhancements:
- Propagate the platform-provided PORT environment variable to N8N_PORT at startup
- Import the health command in the CLI bootstrap